### PR TITLE
Implement generic blog subpage template and subpages

### DIFF
--- a/src/components/blog/BlogGrid.tsx
+++ b/src/components/blog/BlogGrid.tsx
@@ -1,0 +1,16 @@
+import { BlogCard, type BlogContent } from "./BlogCard";
+
+type BlogGrid = {
+    content: BlogContent[];
+};
+
+// Represents the grid of blog cards on blog pages
+export const BlogGrid: React.FC<BlogGrid> = ({ content }) => {
+    return (
+        <div className="grid grid-cols-1 gap-x-6 gap-y-2 md:grid-cols-2 md:gap-y-6 lg:grid-cols-3 lg:gap-y-8">
+            {content.map((content) => (
+                <BlogCard key={content.title} {...content} />
+            ))}
+        </div>
+    );
+};

--- a/src/components/blog/BlogSubpageTemplate.tsx
+++ b/src/components/blog/BlogSubpageTemplate.tsx
@@ -1,0 +1,40 @@
+import React, { type ReactNode } from "react";
+import PageLayout from "../common/PageLayout";
+import PageTitleSection from "../common/PageTitleSection";
+import ContentContainer from "../common/ContentContainer";
+import Image, { type StaticImageData } from "next/image";
+
+type BlogSubpageTemplateProps = {
+    title: string;
+    children?: ReactNode;
+    description: string;
+    src: StaticImageData;
+    alt: string;
+};
+
+// A template for blog subpages See issue #53
+export const BlogSubpageTemplate: React.FC<BlogSubpageTemplateProps> = ({
+    children,
+    title,
+    description,
+    src,
+    alt,
+}) => {
+    return (
+        <PageLayout>
+            <div className="my-2 flex flex-col items-center lg:my-12 lg:flex-row lg:px-8 2xl:my-20 2xl:px-20">
+                <div className="basis-2/5">
+                    <PageTitleSection title={title}>
+                        <h2>{description}</h2>
+                    </PageTitleSection>
+                </div>
+                <div className="basis-3/5">
+                    <Image src={src} alt={alt} objectFit="cover" />
+                </div>
+            </div>
+            <ContentContainer className="my-4 lg:my-20">
+                {children}
+            </ContentContainer>
+        </PageLayout>
+    );
+};

--- a/src/components/blog/ExperiencesSection.tsx
+++ b/src/components/blog/ExperiencesSection.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { BlogCard } from "~/components/blog/BlogCard";
 import { PageSubSection } from "../common/PageSubSection";
 import { type BlogContent } from "~/components/blog/BlogCard";
+import { BlogGrid } from "./BlogGrid";
 
 const TEST_CONTENT: BlogContent[] = [
     {
@@ -33,11 +33,7 @@ const TEST_CONTENT: BlogContent[] = [
 export const ExperiencesSection = () => {
     return (
         <PageSubSection title={"Experiences"}>
-            <div className="grid grid-cols-1 gap-x-6 gap-y-2 md:grid-cols-2 md:gap-y-6 lg:grid-cols-3 lg:gap-y-8">
-                {TEST_CONTENT.map((content) => (
-                    <BlogCard key={content.title} {...content} />
-                ))}
-            </div>
+            <BlogGrid content={TEST_CONTENT} />
         </PageSubSection>
     );
 };

--- a/src/components/blog/FutureInAseanSection.tsx
+++ b/src/components/blog/FutureInAseanSection.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { BlogCard } from "~/components/blog/BlogCard";
 import { PageSubSection } from "../common/PageSubSection";
 import { type BlogContent } from "~/components/blog/BlogCard";
+import { BlogGrid } from "./BlogGrid";
 
 const TEST_CONTENT: BlogContent[] = [
     {
@@ -33,11 +33,7 @@ const TEST_CONTENT: BlogContent[] = [
 export const FutureInAseanSection = () => {
     return (
         <PageSubSection title={"A Future in ASEAN Series"}>
-            <div className="grid grid-cols-1 gap-x-6 gap-y-2 md:grid-cols-2 md:gap-y-6 lg:grid-cols-3 lg:gap-y-8">
-                {TEST_CONTENT.map((content) => (
-                    <BlogCard key={content.title} {...content} />
-                ))}
-            </div>
+            <BlogGrid content={TEST_CONTENT} />
         </PageSubSection>
     );
 };

--- a/src/components/blog/FutureInAseanSection.tsx
+++ b/src/components/blog/FutureInAseanSection.tsx
@@ -32,7 +32,10 @@ const TEST_CONTENT: BlogContent[] = [
 
 export const FutureInAseanSection = () => {
     return (
-        <PageSubSection title={"A Future in ASEAN Series"}>
+        <PageSubSection
+            title={"A Future in ASEAN Series"}
+            titleLink="/blog/futureInAsean"
+        >
             <BlogGrid content={TEST_CONTENT} />
         </PageSubSection>
     );

--- a/src/components/common/PageSubSection.tsx
+++ b/src/components/common/PageSubSection.tsx
@@ -1,16 +1,28 @@
 import React, { type PropsWithChildren } from "react";
+import Link from "next/link";
 
 type PageSubSectionProps = {
     title: string;
+    titleLink?: string;
 };
 export const PageSubSection = ({
     children,
     title,
+    titleLink,
 }: PropsWithChildren<PageSubSectionProps>) => {
     return (
         <section className="px-4 lg:px-9">
             <h2 className="mb-4 text-5xl font-semibold uppercase text-black lg:mb-12">
-                {title}
+                {titleLink ? (
+                    <Link
+                        href={titleLink}
+                        className="transition-all duration-300 hover:text-brandBlue-40"
+                    >
+                        {title}
+                    </Link>
+                ) : (
+                    title
+                )}
             </h2>
             {children}
         </section>

--- a/src/pages/blog/experiences/index.tsx
+++ b/src/pages/blog/experiences/index.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import { PageSubSection } from "../common/PageSubSection";
 import { type BlogContent } from "~/components/blog/BlogCard";
-import { BlogGrid } from "./BlogGrid";
+import { BlogGrid } from "~/components/blog/BlogGrid";
+import { BlogSubpageTemplate } from "~/components/blog/BlogSubpageTemplate";
+import ImpactReportImg from "src/assets/annualImpactReport.png";
 
 const TEST_CONTENT: BlogContent[] = [
     {
@@ -30,10 +30,15 @@ const TEST_CONTENT: BlogContent[] = [
     },
 ];
 
-export const ExperiencesSection = () => {
+export default function experiences() {
     return (
-        <PageSubSection title={"Experiences"} titleLink="/blog/experiences">
+        <BlogSubpageTemplate
+            title={"Experiences"}
+            description="lorem ipsum dolor sit amet"
+            src={ImpactReportImg}
+            alt={"Experiences"}
+        >
             <BlogGrid content={TEST_CONTENT} />
-        </PageSubSection>
+        </BlogSubpageTemplate>
     );
-};
+}

--- a/src/pages/blog/futureInAsean/index.tsx
+++ b/src/pages/blog/futureInAsean/index.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import { PageSubSection } from "../common/PageSubSection";
 import { type BlogContent } from "~/components/blog/BlogCard";
-import { BlogGrid } from "./BlogGrid";
+import { BlogGrid } from "~/components/blog/BlogGrid";
+import { BlogSubpageTemplate } from "~/components/blog/BlogSubpageTemplate";
+import ImpactReportImg from "src/assets/annualImpactReport.png";
 
 const TEST_CONTENT: BlogContent[] = [
     {
@@ -30,10 +30,15 @@ const TEST_CONTENT: BlogContent[] = [
     },
 ];
 
-export const ExperiencesSection = () => {
+export default function experiences() {
     return (
-        <PageSubSection title={"Experiences"} titleLink="/blog/experiences">
+        <BlogSubpageTemplate
+            title={"A Future in ASEAN Series"}
+            description={"lorem ipsum dolor sit amet"}
+            src={ImpactReportImg}
+            alt={"Future in ASEAN"}
+        >
             <BlogGrid content={TEST_CONTENT} />
-        </PageSubSection>
+        </BlogSubpageTemplate>
     );
-};
+}


### PR DESCRIPTION
This pull request adds the generic blog subpage template, resolving #53 .
It also implements 2 blog subpages, Experiences and Future in ASEAN, resolving #51  and #52 .

I've added a placeholder images for both subpages.

I'm not sure how the `/blog` page is supposed to link to the blog subpages, so I've just added a `<Link>` on top of the headings that turns blue when hovered. @javianng please advise! 